### PR TITLE
Make evtMontant title required on EN translation

### DIFF
--- a/src/main/java/org/esupportail/pay/web/validators/PayEvtMontantUpdateValidator.java
+++ b/src/main/java/org/esupportail/pay/web/validators/PayEvtMontantUpdateValidator.java
@@ -41,7 +41,7 @@ public class PayEvtMontantUpdateValidator implements Validator {
 		if(!evtMontant.getFreeAmount() && !evtMontant.getSciencesconf() && (evtMontant.getDbleMontant() == null || evtMontant.getDbleMontant() <= 0.0)) {
 			errors.rejectValue("dbleMontant", "MustBePositive");
 	    }
-		if(evtMontant.getTitle().getTranslation(LOCALE_IDS.fr) == null || evtMontant.getTitle().getTranslation(LOCALE_IDS.fr).isEmpty()) {
+		if(evtMontant.getTitle().getTranslation(LOCALE_IDS.en) == null || evtMontant.getTitle().getTranslation(LOCALE_IDS.en).isEmpty()) {
 			errors.rejectValue("title", "NotEmpty");
 	    }
 		if(evtMontant.getOptionalAddedParams() != null && !evtMontant.getOptionalAddedParams().isEmpty()) {


### PR DESCRIPTION
Since urlId is based on EN translation, make evtMontant title required on EN translation.

Prevent exception when submitting new PayEvtMontant with only french translation.