### PR TITLE
support des urls officielles en .../php/

### DIFF
--- a/src/main/java/org/esupportail/pay/services/PayBoxService.java
+++ b/src/main/java/org/esupportail/pay/services/PayBoxService.java
@@ -198,7 +198,13 @@ public class PayBoxService {
     protected String getPayBoxActionUrl() {
         for (String payboxActionUrl : payboxActionUrls) {
             try {
-                URL url = new URL(payboxActionUrl);
+                String checkUrl = payboxActionUrl;
+                if ("".equals(checkUrl)) continue;
+                int index = checkUrl.lastIndexOf("/php");
+                if (index != -1) {
+                    checkUrl = checkUrl.substring(0, index + 1) + "load.html";
+                }
+                URL url = new URL(checkUrl);
                 URLConnection connection = url.openConnection();
                 connection.connect();
                 connection.getInputStream().read();
@@ -212,7 +218,7 @@ public class PayBoxService {
 
     protected String getCurrentTime() {
         TimeZone tz = TimeZone.getTimeZone("UTC");
-        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
         df.setTimeZone(tz);
         String nowAsISO = df.format(new Date());
         return nowAsISO;


### PR DESCRIPTION
bonjour,

les urls "officielles" de paybox ont changé: il s'agit de https://preprod-tpeweb.paybox.com/php/ pour la préprod et https://tpeweb.paybox.com/php/ et https://tpeweb1.paybox.com/php/ pour la prod

il semble que l'application derrière ces urls est différente de celle qui écoute sur les adresses en .../MYchoix_pagepaiement.cgi
notamment:
- la vérification que le serveur est up ne peut pas se faire en attaquant l'url directement (elle renvoie une erreur 500). il faut utiliser .../load.html selon la doc de paybox
- PBX_TIME doit être strictement au format ISO 8601 : les secondes doivent être présentes

le patch attaché règle ces deux problèmes, tout en restant compatible avec les adresses en .../MYchoix_pagepaiement.cgi