### PR TITLE
Corrige la version de lombok

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
 		<dependency>
 		    <groupId>org.projectlombok</groupId>
 		    <artifactId>lombok</artifactId>
-		    <version>1.18.26</version>
+		    <version>1.18.30</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.apache.taglibs</groupId>


### PR DESCRIPTION
La version de lombok causait une erreur lors du lancement de jetty (`Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid`). Le passage à la version supérieure suffit à résoudre le problème.