### PR TITLE
feat: permettre de mettre un préfixe « texte libre » au libellé de paiement Paybox pour un montant

### DIFF
--- a/src/main/java/org/esupportail/pay/domain/PayEvtMontant.java
+++ b/src/main/java/org/esupportail/pay/domain/PayEvtMontant.java
@@ -78,7 +78,10 @@ public class PayEvtMontant {
     
     Boolean authCas = false;
  
-    String addPrefix = "";
+    @Column(name = "add_prefix")
+    String addPrefixKind = "";
+    
+    String addFreePrefix = "";
     
     String optionalAddedParams = "";
     

--- a/src/main/java/org/esupportail/pay/services/PayBoxService.java
+++ b/src/main/java/org/esupportail/pay/services/PayBoxService.java
@@ -149,14 +149,17 @@ public class PayBoxService {
         PayBoxForm payBoxForm = new PayBoxForm();
         payBoxForm.setActionUrl(getPayBoxActionUrl());
         payBoxForm.setClientEmail(mail);
-        if(payEvtMontant.getAddPrefix() == null || payEvtMontant.getAddPrefix().isEmpty()) {
+        if(StringUtils.isEmpty(payEvtMontant.getAddPrefixKind())) {
             payBoxForm.setCommande(getNumCommande(payEvtMontant.getEvt().getPayboxCommandPrefix(), mail, montantAsCents));
         } else {
+            String addPrefixKind = payEvtMontant.getAddPrefixKind();
             String addPrefix = "";
-            if("field1".equals(payEvtMontant.getAddPrefix())) {
+            if("field1".equals(addPrefixKind)) {
                 addPrefix = field1;
-            } else if("field2".equals(payEvtMontant.getAddPrefix())) {
+            } else if("field2".equals(addPrefixKind)) {
                 addPrefix = field2;
+            } else if("free".equals(addPrefixKind)) {
+                addPrefix = payEvtMontant.getAddFreePrefix();
             }
             payBoxForm.setCommande(getNumCommande(payEvtMontant.getEvt().getPayboxCommandPrefix(), addPrefix, mail, montantAsCents));
         }

--- a/src/main/java/org/esupportail/pay/web/ApplicationConversionServiceFactoryBean.java
+++ b/src/main/java/org/esupportail/pay/web/ApplicationConversionServiceFactoryBean.java
@@ -72,7 +72,7 @@ public class ApplicationConversionServiceFactoryBean extends FormattingConversio
 	public Converter<PayEvtMontant, String> getPayEvtMontantToStringConverter() {
         return new org.springframework.core.convert.converter.Converter<org.esupportail.pay.domain.PayEvtMontant, java.lang.String>() {
             public String convert(PayEvtMontant payboxEvtMontant) {
-                return String.valueOf(payboxEvtMontant.getDbleMontant()) + ' ' + payboxEvtMontant.getUrlId() + ' ' + payboxEvtMontant.getAddPrefix();
+                return String.valueOf(payboxEvtMontant.getDbleMontant()) + ' ' + payboxEvtMontant.getUrlId() + ' ' + payboxEvtMontant.getAddPrefixKind() + ' ' + payboxEvtMontant.getAddFreePrefix();
             }
         };
     }

--- a/src/main/java/org/esupportail/pay/web/admin/PayEvtMontantController.java
+++ b/src/main/java/org/esupportail/pay/web/admin/PayEvtMontantController.java
@@ -68,7 +68,7 @@ public class PayEvtMontantController {
 	
     @ModelAttribute("addPrefixList")
     public List<String> getAddPrefixList() {
-    	return Arrays.asList("", "field1", "field2");
+    	return Arrays.asList("", "field1", "field2", "free");
     }
     
     @RequestMapping(params = "form", produces = "text/html")

--- a/src/main/webapp/WEB-INF/i18n/application.properties
+++ b/src/main/webapp/WEB-INF/i18n/application.properties
@@ -76,6 +76,12 @@ label_org_esupportail_pay_domain_payevt_websiteurl = Web Site Url
 label_org_esupportail_pay_domain_payevtmontant = Evt Montant
 
 label_org_esupportail_pay_domain_payevtmontant_addprefix = Add Prefix
+label_org_esupportail_pay_domain_payevtmontant_addprefixkind_ = None
+label_org_esupportail_pay_domain_payevtmontant_addprefixkind_field1 = Content of field1
+label_org_esupportail_pay_domain_payevtmontant_addprefixkind_field2 = Content of field2
+label_org_esupportail_pay_domain_payevtmontant_addprefixkind_free = Free text below
+label_org_esupportail_pay_domain_payevtmontant_add_free_prefix = Add Prefix : free text
+
 
 label_org_esupportail_pay_domain_payevtmontant_dblemontant = Dble Montant
 

--- a/src/main/webapp/WEB-INF/i18n/application_fr.properties
+++ b/src/main/webapp/WEB-INF/i18n/application_fr.properties
@@ -47,6 +47,14 @@ label_org_esupportail_pay_domain_payevt_websiteurl = URL du site web
 
 label_org_esupportail_pay_domain_payevtmontant = Montant
 
+label_org_esupportail_pay_domain_payevtmontant_addprefix = Ajouter un préfixe au libellé de paiement Paybox
+label_org_esupportail_pay_domain_payevtmontant_addprefixkind_ = Aucun
+label_org_esupportail_pay_domain_payevtmontant_addprefixkind_field1 = Contenu du champ field1
+label_org_esupportail_pay_domain_payevtmontant_addprefixkind_field2 = Contenu du champ field2
+label_org_esupportail_pay_domain_payevtmontant_addprefixkind_free = Texte libre ci-dessous
+label_org_esupportail_pay_domain_payevtmontant_add_free_prefix = Ajouter un préfixe : texte libre
+
+
 label_org_esupportail_pay_domain_payevtmontant_dblemontant = Montant
 
 label_org_esupportail_pay_domain_payevtmontant_dblemontantmax = Montant maxium autoris\u00E9

--- a/src/main/webapp/WEB-INF/views/admin/evtmnts/create.html
+++ b/src/main/webapp/WEB-INF/views/admin/evtmnts/create.html
@@ -150,14 +150,28 @@
            <strong th:text="#{label_org_esupportail_pay_domain_payevtmontant_addprefix}">
            </strong>
           </label>
-          <select class="form-control" id="_addPrefix_id" name="addPrefix" size="1">
+          <select class="form-control" id="_addPrefix_id" name="addPrefixKind" size="1" onchange="handle_addFreePrefix_visibility()">
            <th:block th:each="i :${addPrefixList}">
-            <option th:selected="${i == payEvtMontant.addPrefix ? 'true' : 'false'}" th:text="${i}" th:value="${i}">
+            <option th:selected="${i == payEvtMontant.addPrefixKind ? 'true' : 'false'}" th:text="#{label_org_esupportail_pay_domain_payevtmontant_addprefixkind_ + ${i}}" th:value="${i}">
             </option>
            </th:block>
           </select>
-          <span class="errors" id="_addPrefix_error_id" th:errors="*{addPrefix}" th:if="${#fields.hasErrors('addPrefix')}">
+          <span class="errors" id="_addPrefix_error_id" th:errors="*{addPrefixKind}" th:if="${#fields.hasErrors('addPrefixKind')}">
           </span>
+         </div>
+         <div class="form-group" id="c_org_esupportail_pay_domain_payevtmontant_addFreePrefix">
+             <label>
+                 <strong th:text="#{label_org_esupportail_pay_domain_payevtmontant_add_free_prefix}">
+                 </strong>
+                 <input class="form-control" name="addFreePrefix" th:value="*{addFreePrefix}">
+             </label>
+             <script>
+               function handle_addFreePrefix_visibility() {
+                 const kind = document.querySelector("[name=addPrefixKind]").value
+                 document.querySelector("#c_org_esupportail_pay_domain_payevtmontant_addFreePrefix").style.display = kind === 'free' ? '' : 'none'
+               }
+               handle_addFreePrefix_visibility()
+             </script>
          </div>
         </div>
         <div sec:authorize="!hasRole('ROLE_ADMIN')">

--- a/src/main/webapp/WEB-INF/views/admin/evtmnts/create.html
+++ b/src/main/webapp/WEB-INF/views/admin/evtmnts/create.html
@@ -163,7 +163,6 @@
         <div sec:authorize="!hasRole('ROLE_ADMIN')">
          <input name="freeAmount" type="hidden" th:value="${payEvtMontant.freeAmount}"/>
          <input name="sciencesconf" type="hidden" th:value="${payEvtMontant.sciencesconf}"/>
-         <input name="addPrefix" type="hidden" th:value="${payEvtMontant.addPrefix}"/>
         </div>
         <div class="form-group" id="c_org_esupportail_pay_domain_payEvtMontant_optionalAddedParams">
          <label class="c" for="optionalAddedParams">

--- a/src/main/webapp/WEB-INF/views/admin/evtmnts/update.html
+++ b/src/main/webapp/WEB-INF/views/admin/evtmnts/update.html
@@ -222,20 +222,35 @@
                                 <strong th:text="#{label_org_esupportail_pay_domain_payevtmontant_addprefix}">
                                 </strong>
                             </label>
-                            <select class="form-control" id="_addPrefix_id" name="addPrefix" size="1">
+                            <select class="form-control" id="_addPrefix_id" name="addPrefixKind" size="1" onchange="handle_addFreePrefix_visibility()">
                                 <th:block th:each="i :${addPrefixList}">
-                                    <option th:selected="${i == payEvtMontant.addPrefix ? 'true' : 'false'}" th:text="${i}" th:value="${i}">
+                                    <option th:selected="${i == payEvtMontant.addPrefixKind ? 'true' : 'false'}" th:text="#{label_org_esupportail_pay_domain_payevtmontant_addprefixkind_ + ${i}}" th:value="${i}">
                                     </option>
                                 </th:block>
                             </select>
-                            <span class="errors" id="_addPrefix_error_id" th:errors="*{addPrefix}" th:if="${#fields.hasErrors('addPrefix')}">
+                            <span class="errors" id="_addPrefix_error_id" th:errors="*{addPrefixKind}" th:if="${#fields.hasErrors('addPrefixKind')}">
                             </span>
+                        </div>
+                        <div class="form-group" id="c_org_esupportail_pay_domain_payevtmontant_addFreePrefix">
+                            <label>
+                                <strong th:text="#{label_org_esupportail_pay_domain_payevtmontant_add_free_prefix}">
+                                </strong>
+                                <input class="form-control" name="addFreePrefix" th:value="*{addFreePrefix}">
+                            </label>
+                            <script>
+                              function handle_addFreePrefix_visibility() {
+                                const kind = document.querySelector("[name=addPrefixKind]").value
+                                document.querySelector("#c_org_esupportail_pay_domain_payevtmontant_addFreePrefix").style.display = kind === 'free' ? '' : 'none'
+                              }
+                              handle_addFreePrefix_visibility()
+                            </script>
                         </div>
                     </div>
                     <div sec:authorize="!hasRole('ROLE_ADMIN')">
                         <input name="freeAmount" type="hidden" th:value="*{freeAmount}"/>
                         <input name="sciencesconf" type="hidden" th:value="*{sciencesconf}"/>
-                        <input name="addPrefix" type="hidden" th:value="*{addPrefix}"/>
+                        <input name="addPrefixKind" type="hidden" th:value="*{addPrefixKind}"/>
+                        <input name="addFreePrefix" type="hidden" th:value="*{addFreePrefix}"/>
                     </div>
                     <div class="form-group" id="c_org_esupportail_pay_domain_payEvtMontant_optionalAddedParams">
                         <label class="c" for="optionalAddedParams">


### PR DESCRIPTION
NB : une autre possibilité d'implémentation aurait été un truc un peu plus simple/expert autorisant une valeur avec interprétation de variables, du genre "${field1}". Et on conserverait un cas particulier pour gérer les valeurs "field1" et "field2" (voulant dire "${field1}" et "${field2}").