### PR TITLE
feat: allow default field1/field2 values from authenticated user

### DIFF
--- a/src/main/java/org/esupportail/pay/domain/PayEvtMontant.java
+++ b/src/main/java/org/esupportail/pay/domain/PayEvtMontant.java
@@ -71,6 +71,9 @@ public class PayEvtMontant {
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "field2label")
     Label field2Label; 
+
+    String field1DefaultValueFromUserAttr;
+    String field2DefaultValueFromUserAttr;
     
     Double dbleMontant;
 

--- a/src/main/java/org/esupportail/pay/services/LdapUserContextMapper.java
+++ b/src/main/java/org/esupportail/pay/services/LdapUserContextMapper.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to ESUP-Portail under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * ESUP-Portail licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.esupportail.pay.services;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.naming.NamingException;
+
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.ldap.userdetails.LdapUserDetailsMapper;
+
+class LdapUserContextMapper extends LdapUserDetailsMapper {
+
+    @Override
+    public LdapUserDetails mapUserFromContext(DirContextOperations ctx, String username, Collection<? extends GrantedAuthority> authorities){
+        return new LdapUserDetails(username, authorities, toMap(ctx));
+    }    
+
+    private Map<String, String> toMap(DirContextOperations ctx) {
+        var map = new TreeMap<String, String>();
+        var attrs = ctx.getAttributes().getAll();
+        try {
+            while (attrs.hasMore()) {
+                var attr = attrs.next();
+                if (attr.size() == 1) {
+                    map.put(attr.getID(), (String) attr.get());
+                }
+            }
+        } catch (NamingException e) {
+            throw new RuntimeException("unexpected", e);
+        }
+        return map;
+    }    
+}

--- a/src/main/java/org/esupportail/pay/services/LdapUserDetails.java
+++ b/src/main/java/org/esupportail/pay/services/LdapUserDetails.java
@@ -1,0 +1,25 @@
+package org.esupportail.pay.services;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class LdapUserDetails extends User {
+    private final Map<String, String> attrs;
+
+    public LdapUserDetails(
+            String username,
+            Collection<? extends GrantedAuthority> authorities,
+            Map<String, String> attrs) {
+
+        super(username, "", authorities);
+        this.attrs = attrs;
+    }
+
+    public String getAttr(String name) {
+        return attrs.get(name);
+    }
+
+}

--- a/src/main/java/org/esupportail/pay/web/admin/PayEvtMontantController.java
+++ b/src/main/java/org/esupportail/pay/web/admin/PayEvtMontantController.java
@@ -71,6 +71,11 @@ public class PayEvtMontantController {
     	return Arrays.asList("", "field1", "field2", "free");
     }
     
+    @ModelAttribute("defaultValueFromUserAttrList")
+    public List<String> getDefaultValueFromUserAttrList() {
+        return Arrays.asList("", "sn", "givenName", "displayName", "supannEtuId");
+    }
+
     @ModelAttribute("paiementMultiple_kind_list")
     public List<String> getPaiementMultiple_kind_list() {
     	return Arrays.asList("", PayEvtMontant.paiementMultiple_kind_datesPrecise, PayEvtMontant.paiementMultiple_kind_simulateFrequence);

--- a/src/main/java/org/esupportail/pay/web/anonyme/PayController.java
+++ b/src/main/java/org/esupportail/pay/web/anonyme/PayController.java
@@ -31,6 +31,7 @@ import org.esupportail.pay.domain.*;
 import org.esupportail.pay.exceptions.EntityNotFoundException;
 import org.esupportail.pay.services.PayBoxServiceManager;
 import org.esupportail.pay.services.PayEvtMontantService;
+import org.esupportail.pay.services.LdapUserDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.AbstractResource;
 import org.springframework.security.core.Authentication;
@@ -154,10 +155,18 @@ public class PayController {
 		}
 	
     	Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    	if(auth!=null && auth.isAuthenticated() && auth.getPrincipal() instanceof InetOrgPerson) {
-    		InetOrgPerson person = (InetOrgPerson)auth.getPrincipal();
+    	if(auth!=null && auth.isAuthenticated() && auth.getPrincipal() instanceof LdapUserDetails) {
+    		var person = (LdapUserDetails)auth.getPrincipal();
     		if(person != null) {
-    			uiModel.addAttribute("mail", person.getMail());
+    			uiModel.addAttribute("mail", person.getAttr("mail"));
+    			var field1Attr = evtMontant.getField1DefaultValueFromUserAttr();
+    			if (StringUtils.isNotEmpty(field1Attr)) {
+    			    uiModel.addAttribute("field1", person.getAttr(field1Attr));
+    			}
+    			var field2Attr = evtMontant.getField2DefaultValueFromUserAttr();
+    			if (StringUtils.isNotEmpty(field2Attr)) {
+    			    uiModel.addAttribute("field2", person.getAttr(field2Attr));
+    			}
     		}
     	}
     	

--- a/src/main/resources/META-INF/spring/applicationContext-security-cas.xml
+++ b/src/main/resources/META-INF/spring/applicationContext-security-cas.xml
@@ -138,7 +138,7 @@
 		<beans:constructor-arg ref="ldapUserSearch"/>
 		<beans:constructor-arg ref="payboxLdapAuthoritiesPopulator" />
 		<beans:property name="userDetailsMapper">
-			<beans:bean class="org.springframework.security.ldap.userdetails.InetOrgPersonContextMapper"/>
+			<beans:bean class="org.esupportail.pay.services.LdapUserContextMapper"/>
 		</beans:property>
 	</beans:bean>
 	

--- a/src/main/webapp/WEB-INF/i18n/application.properties
+++ b/src/main/webapp/WEB-INF/i18n/application.properties
@@ -99,6 +99,9 @@ label_org_esupportail_pay_domain_payevtmontant_freeamount = Free Amount
 
 label_org_esupportail_pay_domain_payevtmontant_montant_placeholder = amount in euros
 
+payevtmontant_field1DefaultValueFromUserAttr = Connected user attribute used as default value (sn, givenName, displayName...)
+payevtmontant_field2DefaultValueFromUserAttr = Connected user attribute used as default value (sn, givenName, displayName...)
+
 paiementMultiple_incompatible_avec_freeAmount = "Installment payments" is not compatible with "Free Amount"
 paiementMultiple_montant_total_not_equal = The sum of installment payments ({0} \u20ac) must equal "Amount" ({1} \u20ac)
 

--- a/src/main/webapp/WEB-INF/i18n/application.properties
+++ b/src/main/webapp/WEB-INF/i18n/application.properties
@@ -99,8 +99,14 @@ label_org_esupportail_pay_domain_payevtmontant_freeamount = Free Amount
 
 label_org_esupportail_pay_domain_payevtmontant_montant_placeholder = amount in euros
 
-payevtmontant_field1DefaultValueFromUserAttr = Connected user attribute used as default value (sn, givenName, displayName...)
-payevtmontant_field2DefaultValueFromUserAttr = Connected user attribute used as default value (sn, givenName, displayName...)
+payevtmontant_field1DefaultValueFromUserAttr = Choose default value (among connected user CAS attributes)
+payevtmontant_field2DefaultValueFromUserAttr = Choose default value (among connected user CAS attributes)
+
+payevtmontant_field1DefaultValueFromUserAttr_ = No default value
+payevtmontant_field1DefaultValueFromUserAttr_sn = Last name
+payevtmontant_field1DefaultValueFromUserAttr_givenName = First name
+payevtmontant_field1DefaultValueFromUserAttr_displayName = First name and Last name
+payevtmontant_field1DefaultValueFromUserAttr_supannEtuId = Student identifier
 
 paiementMultiple_incompatible_avec_freeAmount = "Installment payments" is not compatible with "Free Amount"
 paiementMultiple_montant_total_not_equal = The sum of installment payments ({0} \u20ac) must equal "Amount" ({1} \u20ac)

--- a/src/main/webapp/WEB-INF/i18n/application_fr.properties
+++ b/src/main/webapp/WEB-INF/i18n/application_fr.properties
@@ -69,8 +69,14 @@ label_org_esupportail_pay_domain_payevtmontant_field2label = Champ2
 
 label_org_esupportail_pay_domain_payevtmontant_freeamount = Montant libre
 
-payevtmontant_field1DefaultValueFromUserAttr = Attribut de l'utilisateur connecté utilisé comme valeur par défaut (sn, givenName, displayName...)
-payevtmontant_field2DefaultValueFromUserAttr = Attribut de l'utilisateur connecté utilisé comme valeur par défaut (sn, givenName, displayName...)
+payevtmontant_field1DefaultValueFromUserAttr = Choix de la valeur par défaut (parmi les attributs CAS de l'utilisateur)
+payevtmontant_field2DefaultValueFromUserAttr = Choix de la valeur par défaut (parmi les attributs CAS de l'utilisateur)
+
+payevtmontant_field1DefaultValueFromUserAttr_ = Pas de valeur par d\u00E9faut
+payevtmontant_field1DefaultValueFromUserAttr_sn = Nom
+payevtmontant_field1DefaultValueFromUserAttr_givenName = Pr\u00E9nom
+payevtmontant_field1DefaultValueFromUserAttr_displayName = Pr\u00E9nom et Nom
+payevtmontant_field1DefaultValueFromUserAttr_supannEtuId = Num\u00E9ro \u00E9tudiant
 
 payevtmontant_montant_placeholder = montant en euros
 

--- a/src/main/webapp/WEB-INF/i18n/application_fr.properties
+++ b/src/main/webapp/WEB-INF/i18n/application_fr.properties
@@ -69,6 +69,9 @@ label_org_esupportail_pay_domain_payevtmontant_field2label = Champ2
 
 label_org_esupportail_pay_domain_payevtmontant_freeamount = Montant libre
 
+payevtmontant_field1DefaultValueFromUserAttr = Attribut de l'utilisateur connecté utilisé comme valeur par défaut (sn, givenName, displayName...)
+payevtmontant_field2DefaultValueFromUserAttr = Attribut de l'utilisateur connecté utilisé comme valeur par défaut (sn, givenName, displayName...)
+
 payevtmontant_montant_placeholder = montant en euros
 
 paiementMultiple_incompatible_avec_freeAmount = La fonctionnalité paiement échelonné est incompatible avec « Montant libre »

--- a/src/main/webapp/WEB-INF/layouts/admin.html
+++ b/src/main/webapp/WEB-INF/layouts/admin.html
@@ -79,7 +79,7 @@
 <div th:replace="~{../fragments/footer.html :: footer}"></div>
 </body>
 <style>
-  label > input {
+  label > input, label > select {
     font-weight: 400;
   }
   label {

--- a/src/main/webapp/WEB-INF/views/admin/evtmnts/field1_field2.html
+++ b/src/main/webapp/WEB-INF/views/admin/evtmnts/field1_field2.html
@@ -19,7 +19,12 @@
     <div class="form-group" sec:authorize="hasRole('ROLE_ADMIN')">
         <label class="c">
             <strong th:text="#{payevtmontant_field1DefaultValueFromUserAttr}"></strong>
-            <input class="form-control" th:field="*{field1DefaultValueFromUserAttr}" type="text"/>
+            <select class="form-control" name="field1DefaultValueFromUserAttr">
+                <th:block th:each="i :${defaultValueFromUserAttrList}">
+                    <option th:selected="${i == payEvtMontant.field1DefaultValueFromUserAttr ? 'true' : 'false'}" th:text="#{payevtmontant_field1DefaultValueFromUserAttr_ + ${i}}" th:value="${i}">
+                    </option>
+                </th:block>
+            </select>
         </label>
         <span class="errors" th:errors="*{field1DefaultValueFromUserAttr}" th:if="${#fields.hasErrors('field1DefaultValueFromUserAttr')}">
     </div>
@@ -45,7 +50,12 @@
     <div class="form-group" sec:authorize="hasRole('ROLE_ADMIN')">
         <label class="c">
             <strong th:text="#{payevtmontant_field2DefaultValueFromUserAttr}"></strong>
-            <input class="form-control" th:field="*{field2DefaultValueFromUserAttr}" type="text"/>
+            <select class="form-control" name="field2DefaultValueFromUserAttr">
+                <th:block th:each="i :${defaultValueFromUserAttrList}">
+                    <option th:selected="${i == payEvtMontant.field2DefaultValueFromUserAttr ? 'true' : 'false'}" th:text="#{payevtmontant_field1DefaultValueFromUserAttr_ + ${i}}" th:value="${i}">
+                    </option>
+                </th:block>
+            </select>
         </label>
         <span class="errors" th:errors="*{field2DefaultValueFromUserAttr}" th:if="${#fields.hasErrors('field2DefaultValueFromUserAttr')}">
     </div>

--- a/src/main/webapp/WEB-INF/views/admin/evtmnts/field1_field2.html
+++ b/src/main/webapp/WEB-INF/views/admin/evtmnts/field1_field2.html
@@ -16,6 +16,13 @@
             </label>
         </div>
     </div>
+    <div class="form-group" sec:authorize="hasRole('ROLE_ADMIN')">
+        <label class="c">
+            <strong th:text="#{payevtmontant_field1DefaultValueFromUserAttr}"></strong>
+            <input class="form-control" th:field="*{field1DefaultValueFromUserAttr}" type="text"/>
+        </label>
+        <span class="errors" th:errors="*{field1DefaultValueFromUserAttr}" th:if="${#fields.hasErrors('field1DefaultValueFromUserAttr')}">
+    </div>
 </fieldset>
 <fieldset>
     <legend>
@@ -35,4 +42,23 @@
             </label>
         </div>
     </div>
+    <div class="form-group" sec:authorize="hasRole('ROLE_ADMIN')">
+        <label class="c">
+            <strong th:text="#{payevtmontant_field2DefaultValueFromUserAttr}"></strong>
+            <input class="form-control" th:field="*{field2DefaultValueFromUserAttr}" type="text"/>
+        </label>
+        <span class="errors" th:errors="*{field2DefaultValueFromUserAttr}" th:if="${#fields.hasErrors('field2DefaultValueFromUserAttr')}">
+    </div>
 </fieldset>
+<script>
+    function handle_fieldDefaultValueFromUserAttr_visibility(authCasElt) {
+      for (const elt of document.querySelectorAll("[name^=field][name$=DefaultValueFromUserAttr]")) {
+          elt.classList.toggle('hide-form-group', !authCasElt.checked)
+      }
+    }
+    window.addEventListener("load", _ => {
+      const authCasElt = document.querySelector("[name=authCas]")
+      handle_fieldDefaultValueFromUserAttr_visibility(authCasElt)
+      authCasElt.addEventListener('change', _ => handle_fieldDefaultValueFromUserAttr_visibility(authCasElt))
+    })
+</script>

--- a/src/main/webapp/WEB-INF/views/anonyme/evtmnt.html
+++ b/src/main/webapp/WEB-INF/views/anonyme/evtmnt.html
@@ -65,13 +65,13 @@
                         <label class="control-label" for="field1">
                             [[${payevtmontant.field1Label.getTranslation(locale)}]]
                         </label>
-                        <input class="form-control" name="field1" id="field1" type="text"/>
+                        <input class="form-control" name="field1" id="field1" type="text" th:value="${field1}"/>
                     </div>
                     <div class="form-group">
                         <label class="control-label" for="field2">
                             [[${payevtmontant.field2Label.getTranslation(locale)}]]
                         </label>
-                        <input class="form-control" name="field2" id="field2" type="text"/>
+                        <input class="form-control" name="field2" id="field2" type="text" th:value="${field2}"/>
                     </div>
                     <th:block th:if="${payevtmontant.isBillingAddressRequired}">
                         <div class="panel panel-default">


### PR DESCRIPTION
NB:
- first commit uses <input type="text"> which expects an LDAP attribute name
- second commit replaces this <input type="text"> with a <select> of various useful attrs (sn givenName displayName supannEtuId)

If ok to force a list of attrs, the 2 commits can be squashed.